### PR TITLE
 Adds the Chocolatey package as a way to install the Google Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 - **The files with the extension `dmg`, and the file named `Google-Docs.zip` are the packages for the Apple macOS Operating System.**
 - **The Files with the extension `yml` contains the binary details of the OS-Specific Package. `latest.yml` is for Windows, `latest-macos` is for macOS and `latest-linux` is for Linux. In most cases you don't need to download them.**
 
+On Windows, instead of manually downloading the releases, on your computer, you can install/update it using the [Chocolatey package](https://community.chocolatey.org/packages/unofficial-google-docs-client):
+```powershell
+choco install unofficial-google-docs-client
+```
+
 ## Final Words ✨
 **Thanks for Using it and we encourage users to use it.**
 


### PR DESCRIPTION
Hi @Google-Docs_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1312) and now, we can install **unofficial-google-docs-client** using [Chocolatey](https://community.chocolatey.org/packages/unofficial-google-docs-client).

For now, only the latest version (`2022.6.1`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

